### PR TITLE
fix FORTUTF definition check

### DIFF
--- a/cmake/fortutf.cmake
+++ b/cmake/fortutf.cmake
@@ -110,10 +110,10 @@ function(FortUTF_Find_Tests)
     write_file( ${FORTUTF_PROJECT_TEST_SCRIPT} "    CALL TEST_SUMMARY" APPEND )
     write_file( ${FORTUTF_PROJECT_TEST_SCRIPT} "END PROGRAM" APPEND )
 
+    if(NOT DEFINED ${FORTUTF})
+        set(FORTUTF FortUTF)
+    endif()
     if(NOT TARGET ${FORTUTF})
-        if(NOT DEFINED ${FORTUTF})
-            set(FORTUTF FortUTF)
-        endif()
         ADD_LIBRARY(${FORTUTF} ${FORTUTF_SRCS})
     endif()
 


### PR DESCRIPTION
Hello, I really like your test framework, and I am using it with CMake `FetchContent`.
However, there is a bug when calling `FetchContent_MakeAvailable` from outside.
This PR fixes the problem. Please consider merging this fix.
Thank you very much.