### PR TITLE
Fix module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT BUILD_TESTS)
     set_target_properties(
         ${FORTUTF}
         PROPERTIES
-        Fortran_MODULE_DIRECTORY "${Fortran_MODULE_DIRECTORY}"
+        Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,19 +11,24 @@ message(STATUS "\tUsing compiler: ${CMAKE_Fortran_COMPILER}")
 option(BUILD_TESTS "Build the FortUTF Unit Tests" OFF)
 option(BUILD_EXAMPLES "Build the FortUTF Example Project" OFF)
 
-set(Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+get_directory_property(hasParent PARENT_DIRECTORY)
+if(hasParent)
+  set(Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules PARENT_SCOPE)
+else()
+  set(Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
+endif()
 
 if(NOT BUILD_TESTS)
     add_library(${FORTUTF} ${FUTF_SRCS})
     set_target_properties(
         ${FORTUTF}
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
     )
     set_target_properties(
         ${FORTUTF}
         PROPERTIES
-        Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules
+        Fortran_MODULE_DIRECTORY ${Fortran_MODULE_DIRECTORY}
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT BUILD_TESTS)
     set_target_properties(
         ${FORTUTF}
         PROPERTIES
-        Fortran_MODULE_DIRECTORY ${Fortran_MODULE_DIRECTORY}
+        Fortran_MODULE_DIRECTORY "${Fortran_MODULE_DIRECTORY}"
     )
 endif()
 

--- a/cmake/fortutf.cmake
+++ b/cmake/fortutf.cmake
@@ -118,7 +118,7 @@ function(FortUTF_Find_Tests)
         set_target_properties(
             ${FORTUTF}
             PROPERTIES
-            Fortran_MODULE_DIRECTORY "${Fortran_MODULE_DIRECTORY}"
+            Fortran_MODULE_DIRECTORY ${Fortran_MODULE_DIRECTORY}
         )
     endif()
 

--- a/cmake/fortutf.cmake
+++ b/cmake/fortutf.cmake
@@ -118,7 +118,7 @@ function(FortUTF_Find_Tests)
         set_target_properties(
             ${FORTUTF}
             PROPERTIES
-            Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
+            Fortran_MODULE_DIRECTORY "${Fortran_MODULE_DIRECTORY}"
         )
     endif()
 

--- a/cmake/fortutf.cmake
+++ b/cmake/fortutf.cmake
@@ -114,7 +114,12 @@ function(FortUTF_Find_Tests)
         set(FORTUTF FortUTF)
     endif()
     if(NOT TARGET ${FORTUTF})
-        ADD_LIBRARY(${FORTUTF} ${FORTUTF_SRCS})
+        add_library(${FORTUTF} ${FORTUTF_SRCS})
+        set_target_properties(
+            ${FORTUTF}
+            PROPERTIES
+            Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
+        )
     endif()
 
     add_executable(${PROJECT_NAME}_Tests ${FORTUTF_PROJECT_SRC_FILES} ${TEST_LIST} ${FORTUTF_PROJECT_TEST_SCRIPT})


### PR DESCRIPTION
Hello,

In my previous PR, I did not realize that the module directory path is inconsistent with and without the option `BUILD_TESTS`.

This PR fixes the module path to `${CMAKE_CURRENT_BINARY_DIR}/modules` for both options.

I also added a `PARENT_SCOPE` definition for `Fortran_MODULE_DIRECTORY` so that the cmake function `FortUTF_Find_Tests` also works when  FortUTF is fetched by `FetchContent`.
(The above solution can also be replaced by passing a `Fortran_MODULE_DIRECTORY` argument to the function, but this will changes the function interface.)