### PR TITLE
Fix error code

### DIFF
--- a/.github/workflows/futs.yml
+++ b/.github/workflows/futs.yml
@@ -41,7 +41,7 @@ jobs:
              fi
       - name: Run Example Tests
         run: |
-             ./build/examples/demo_project/DEMO_PROJ_Tests
+             ./build/examples/demo_project/DEMO_PROJ_Tests || 
              if [ $? -eq 1 ]; then
                 echo "Unit Tests failed as expected"
                 exit 0

--- a/.github/workflows/futs.yml
+++ b/.github/workflows/futs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build Tests
         run: |
             gfortran-12 --version
-            cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKE_Fortran_COMPILER=$(which gfortran-12)
+            cmake -H. -Bbuild -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DCMAKE_Fortran_COMPILER=$(which gfortran-12)
             cmake --build build
       - name: Run Tests
         run: |

--- a/.github/workflows/futs.yml
+++ b/.github/workflows/futs.yml
@@ -39,6 +39,16 @@ jobs:
                 echo "Unit Tests failed"
                 exit 1
              fi
+      - name: Run Example Tests
+        run: |
+             ./build/examples/demo_project/DEMO_PROJ_Tests
+             if [ $? -eq 1 ]; then
+                echo "Unit Tests failed as expected"
+                exit 0
+             else
+                echo "Unit Tests that should fail passed"
+                exit 1
+             fi
       - name: Get Coverage Data
         continue-on-error: true
         run: |

--- a/src/suite.f90
+++ b/src/suite.f90
@@ -112,7 +112,9 @@ MODULE FUTF_SUITE
         ENDIF
 
         IF(.NOT. PRESENT(QUIET)) THEN
-            IF(FUTF_EXIT_CODE == 1) THEN
+            IF(FUTF_EXIT_CODE == 0) THEN
+                STOP
+            ELSE
                 ERROR STOP FUTF_EXIT_CODE
             ENDIF
         ENDIF

--- a/src/suite.f90
+++ b/src/suite.f90
@@ -113,7 +113,7 @@ MODULE FUTF_SUITE
 
         IF(.NOT. PRESENT(QUIET)) THEN
             IF(FUTF_EXIT_CODE == 1) THEN
-                STOP
+                ERROR STOP FUTF_EXIT_CODE
             ENDIF
         ENDIF
     END SUBROUTINE


### PR DESCRIPTION
Hello,

I am sorry. I made a mistake in the last PR, where I replaced the GNU-specific command `EXIT` with `STOP`.
`STOP` is a normal exit and returns error code 0, whereas what should be used here is `ERROR STOP`.

I fixed the problem that the error code is not passed with this PR, and I added a CI test for the demo example (which should fail), so that this error is not repeated in the future.

You can see in [this CI](https://github.com/yanjen/FortUTF/actions/runs/8553131492/job/23435653945), the example test failed because the error code is 0. And in the [latest CI](https://github.com/yanjen/FortUTF/actions/runs/8553847343/job/23437869668), the example test passes with error code 1.