### PR TITLE
Fix non-const stop code

### DIFF
--- a/src/suite.f90
+++ b/src/suite.f90
@@ -115,7 +115,7 @@ MODULE FUTF_SUITE
             IF(FUTF_EXIT_CODE == 0) THEN
                 STOP
             ELSE
-                ERROR STOP FUTF_EXIT_CODE
+                ERROR STOP
             END IF
         END IF
     END SUBROUTINE


### PR DESCRIPTION
Hello,

The Fortran 2008 standard states that stop codes should be a constant expression.
This creates an error when one enforces the Fortran 2008 standard with the `-std=f2008` flag.
Since the error code is always 1, and `ERROR STOP` already exits with an error, I propose to remove the stop code.